### PR TITLE
chore: Enable OSDv4 monitoring

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -94,9 +94,14 @@ objects:
   metadata:
     labels:
       service: metrics-accumulator
+      monitoring: enabled
     name: metrics-accumulator
   spec:
     ports:
+    - port: 5000
+      name: metrics
+      targetPort: ${{METRICS_COLLECTOR_SERVICE_PORT}}
+      protocol: TCP
     - port: ${{METRICS_COLLECTOR_SERVICE_PORT}}
       name: "${METRICS_COLLECTOR_SERVICE_PORT}"
       targetPort: ${{METRICS_COLLECTOR_SERVICE_PORT}}


### PR DESCRIPTION
- Add monitoring: enabled` to enable OSD v4 monitoring. There is already a ServiceMonitor instance running which scraps metrics from all services which has the above label.
- Add another Service port with name `metrics`, with targetPort as the existing one.